### PR TITLE
Docker/runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,10 @@ WORKDIR /home/${UNAME}
 RUN cd /home/${UNAME} && git clone https://github.com/plummm/SyzScope.git
 # Install SyzScope python dependencies
 RUN cd /home/${UNAME}/SyzScope/ && pip3 install -r requirements.txt
-# Install SyzScope system dependencies
+
+# FIXME: Install SyzScope system dependencies
 #RUN cd /home/${UNAME}/SyzScope/ && python3 syzscope --install-requirements
-RUN cd /home/${UNAME}/SyzScope/syzscope/scripts/ && bash -x requirements.sh
+#RUN cd /home/${UNAME}/SyzScope/syzscope/scripts/ && bash -x requirements.sh
 
 WORKDIR /home/${UNAME}/SyzScope
 CMD ["bash"]


### PR DESCRIPTION
Features:
* Initialization of docker environment for `SyzScope` to expose a reproducible build for end-users.

Hi, I've added a `Dockerfile` to expose a reproducible build for researchers looking to reproduce the research. 

I'm aware that there are already docker images on dockerhub but I was interested in identifying the minimum system dependencies and permissions and being able to make changes if needed.

I've tested building and running `SyzScope` using this docker build on my host running Ubuntu 20.04 LTS and Docker version 20.10.17. 

There's a small quirk that I'm going to push a fix for related to the `syzkaller` build at run-time. Additionally, despite the kernel build running to completion, my target kernel would immediately exit in QEMU. 

However by copying over the `bzImage` and `vmlinux` files from the `etenal/syzscope:ready2go` container image, I was able to reproduce the [CVE-2018-25015](https://github.com/plummm/SyzScope/blob/master/tutorial/examples/WARNING_held_lock_freed.md) example by running the command `python3 syzscope -i a8d38d1b68ffc744c53bd9b9fc1dbd6c86b1afe2 -RP -SE --timeout-symbolic-execution 3600`.

Currently, the build aligns more with the `etenal/syzscope:mini` container image. For some reason, running `requirements.sh` in the docker build isn't persisting the changes in order to have a build that aligns with the `etenal/syzscope:ready2go` container image.