### PR TITLE
fixed syzkaller build via make clean delay

### DIFF
--- a/syzscope/scripts/deploy.sh
+++ b/syzscope/scripts/deploy.sh
@@ -160,9 +160,9 @@ if [ ! -f "$CASE_PATH/.stamp/BUILD_SYZKALLER" ]; then
   #go get -u -d github.com/google/syzkaller/prog
   #fi
   cd $GOPATH/src/github.com/google/syzkaller || exit 1
-  make clean
   git stash --all || set_git_config
   git checkout -f 9b1f3e665308ee2ddd5b3f35a078219b5c509cdb
+  make clean
   #git checkout -
   #retrieve_proper_patch
   cp $PATCHES_PATH/syzkaller-9b1f3e6.patch ./syzkaller.patch


### PR DESCRIPTION
The latest version of syzkaller commit `0fbd49f48637cff2f7cf1ab0150e2c4ce8d97527` results in a Makefile error where the go version is detected and various imports are found to be undefined. 

This error is present upon running the `make clean` in `syzscope/scripts/deploy.sh`

The error log appears as follows:
```
2023-05-11 13:50:23,726 [0] b'+ cd /home/user/SyzScope/work/incomplete/a8d38d1/gopath/src/github.com/google/syzkaller\n'
2023-05-11 13:50:23,726 [0] b'+ make clean\n'
2023-05-11 13:50:23,734 [0] b'Makefile:32: \x1b[31mrun command via tools/syz-env for best compatibility, see:\x1b(B\x1b[m\n'
2023-05-11 13:50:23,734 [0] b'Makefile:33: \x1b[31mhttps://github.com/google/syzkaller/blob/master/docs/contributing.md#using-syz-env\x1b(B\x1b[m\n'
2023-05-11 13:50:24,337 [0] b'# github.com/google/syzkaller/pkg/image\n'
2023-05-11 13:50:24,337 [0] b'pkg/image/compression.go:39:26: undefined: io.Discard\n'
2023-05-11 13:50:24,337 [0] b'pkg/image/compression.go:60:18: undefined: io.ReadAll\n'
2023-05-11 13:50:24,342 [0] b'note: module requires Go 1.19\n'
2023-05-11 13:50:24,538 [0] b'# golang.org/x/sys/unix\n'
2023-05-11 13:50:24,539 [0] b'vendor/golang.org/x/sys/unix/syscall.go:83:16: undefined: unsafe.Slice\n'
2023-05-11 13:50:24,539 [0] b'vendor/golang.org/x/sys/unix/syscall_linux.go:2271:9: undefined: unsafe.Slice\n'
2023-05-11 13:50:24,539 [0] b'vendor/golang.org/x/sys/unix/syscall_unix.go:118:7: undefined: unsafe.Slice\n'
2023-05-11 13:50:24,539 [0] b'vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice\n'
2023-05-11 13:50:24,971 [0] b'Makefile:49: *** syz-make failed.  Stop.\n'
```

A simple fix I've found for this is to delay the `make clean` until **after** the target commit (in which custom syzkaller patches are applied) is checked out.