### PR TITLE
Fix extraction error

### DIFF
--- a/syzscope/interface/vm/gdb.py
+++ b/syzscope/interface/vm/gdb.py
@@ -44,6 +44,7 @@ class GDBHelper:
         raw = self.sendline('version')
         for line in raw.split('\n'):
             line = line.strip('\n')
+            line = line.strip()
             versions = line.split(':')
             if 'Pwndbg' in versions[0]:
                 return True
@@ -210,7 +211,7 @@ class GDBHelper:
         #print("send", cmd)
         self._sendline(cmd)
         raw = self.waitfor("pwndbg>", timeout)
-        return raw
+        return self._escape_ansi(raw)
     
     def recv(self):
         return self.gdb_inst.recv()


### PR DESCRIPTION
Fix extraction error

1. filter colorful output of pwndbg
2. strip output of pwndbg

Maybe it's time for us to implement a communication channel between other program and gdb based on gdb python API. The behavior of API is much more stable than command line...